### PR TITLE
Fixing not function.

### DIFF
--- a/src/govote.go
+++ b/src/govote.go
@@ -5575,7 +5575,7 @@ func UDN_Not(db *sql.DB, udn_schema map[string]interface{}, udn_start *UdnPart, 
 	UdnLog(udn_schema, "Not: %v\n", SnippetData(input, 60))
 
 	value := "0"
-	if input != nil && input != "0" {
+	if input != nil && input == "0" {
 		value = "1"
 	}
 


### PR DESCRIPTION
Tested using:

[
    [
        [
            "__input.'0'.__not.__set.set_api_result.out",
            ""
        ]
    ]
]

which returns 1, and

[
    [
        [
            "__input.'123'.__not.__set.set_api_result.out",
            ""
        ]
    ]
]

which returns 0.